### PR TITLE
Require page slug to be unique

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,10 +15,17 @@ class PagesController < ApplicationController
     else
       render :new
     end
+  rescue ActiveRecord::RecordNotUnique => e
+    if e.message.match?(/pages_slug_idx/)
+      @page.errors.add(:title, :taken)
+      render :new
+    else
+      raise
+    end
   end
 
   def show
-    @page = Page.find_by!(slug: params[:slug])
+    @page = Page.find_by_slug_ignoring_case!(params[:slug])
   end
 
   private

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,6 +6,7 @@ class Page < ApplicationRecord
       with: /\A[A-Za-z0-9\-_.!~*'() ]*\z/,
       message: "contains invalid characters",
     }
+  validate :title_must_be_unique
   validates :content,
     exclusion: { in: [nil] },
     length: { maximum: 1_000_000 }
@@ -14,10 +15,30 @@ class Page < ApplicationRecord
     slug
   end
 
+  def self.exists_with_slug_ignoring_case?(slug)
+    with_slug_ignoring_case(slug).exists?
+  end
+
+  def self.find_by_slug_ignoring_case!(slug)
+    with_slug_ignoring_case(slug).first!
+  end
+
   def title=(value)
     super(value)
     if value
       self.slug = value.tr(" ", "_")
+    end
+  end
+
+  private
+
+  def self.with_slug_ignoring_case(slug)
+    where(arel_table[:slug].lower.eq(slug.downcase))
+  end
+
+  def title_must_be_unique
+    if Page.exists_with_slug_ignoring_case?(slug)
+      errors.add(:title, :taken)
     end
   end
 end


### PR DESCRIPTION
Prior to this change it was possible to create multiple pages with the
same title/slug. When visiting a page, the database would select the
first row with the matching slug but in an unspecified order.

This is obviously not desired behavior: a page URL should correspond to
exactly one page.

This commit changes the behavior to require unique (case insensitive)
page slugs.

This is case insensitive because it makes some intuitive sense that,
for example, `/Postgresql` and `/PostgreSQL` should refer to the same
page.

The comparison is case insensitive rather than just downcasing the slug
itself since it would be good to retain case information rather than
requiring all pages to be cased in a certain way (e.g. we want to be
able to allow a page with the slug `/PostgreSQL`)

Note that this restriction is ultimately on the *slug*, not the title
itself. Since the slug is derived from the title and multiple titles can
convert to the same slug, this is more restrictive, e.g. it's not
allowed to have two pages with titles "My page" and "My_page", even
though they would be unique *titles* since they both convert to the same
slug.

The UI refers to the validation being on the title since the
slug is derived from the title and that's the only field the user is
aware of.

A database constraint is required to implement this since app-level
uniqueness validations can't handle the race condition where a page is
being validated, the app selects for existing pages with that slug,
finding none it proceeds to attempt to save, but then a page with the
same slug is inserted first (between the validation succeeding and the
other page saving).

This necessitates rescuing an ActiveRecord::RecordNotUnique exception
in the create action in the controller and then, for consistency with
the other validations, adding an error to the Page.

This commit *also* adds an app-level validation even though it's
not strictly necessary (since we have to have the DB constraint anyway)
and even though it necessitates an additional SELECT for every new page
creation because it's nice for the user to get all validation errors at
once. If we only had the database constraint, if a user attempted to
create a page that had both a nonunique slug and content that was too
long, they would first get the "content too long" error and then after
fixing that and submitting again, they'd get the uniqueness error.